### PR TITLE
82 config commands

### DIFF
--- a/abm/lib/__init__.py
+++ b/abm/lib/__init__.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, json
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 #from common import parse_profile
@@ -6,6 +6,7 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 INVOCATIONS_DIR = "invocations"
 METRICS_DIR = "metrics"
 
+parser = None
 
 class Keys:
     NAME = 'name'
@@ -16,6 +17,5 @@ class Keys:
     DATASET_ID = 'dataset_id'
     HISTORY_BASE_NAME = 'output_history_base_name'
     HISTORY_NAME = 'history_name'
-
 
 

--- a/abm/lib/common.py
+++ b/abm/lib/common.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import yaml
+from ruamel.yaml import YAML
 import subprocess
 import bioblend.galaxy
 # from lib import GALAXY_SERVER, API_KEY, KUBECONFIG
@@ -71,21 +71,45 @@ def get_context(profile_name: str):
     return Context(profile_name)
 
 
+def create_parser():
+    print('Creating a YAML parser')
+    return YAML()
+
+
+def get_yaml_parser(parser = create_parser()):
+    if parser is None:
+        print('No parser provided.')
+        parser = create_parser()
+    return parser
+
+
 def load_profiles():
     '''
     Load the profile configuration file.
 
     :return: a dictionary containing the YAML content of the configuration.
     '''
+    yaml = get_yaml_parser()
     profiles = None
     for profile_path in PROFILE_SEARCH_PATH:
         profile_path = os.path.expanduser(profile_path)
         if os.path.exists(profile_path):
             with open(profile_path, 'r') as f:
                 # print(f'Loading profile from {profile_path}')
-                profiles = yaml.safe_load(f)
+                profiles = yaml.load(f)
             break
     return profiles
+
+
+def save_profiles(profiles: dict):
+    yaml = YAML()
+    for profile_path in PROFILE_SEARCH_PATH:
+        path = os.path.expanduser(profile_path)
+        if os.path.exists(path):
+            with open(path, 'w') as f:
+                yaml.dump(profiles, f)
+            print(f"Saved profiles to {path}")
+            return
 
 
 def parse_profile(profile_name: str):

--- a/abm/lib/common.py
+++ b/abm/lib/common.py
@@ -1,12 +1,10 @@
 import os
 import sys
-from ruamel.yaml import YAML
 import subprocess
+from ruamel.yaml import YAML
+import json
 import bioblend.galaxy
-# from lib import GALAXY_SERVER, API_KEY, KUBECONFIG
 import lib
-
-# global GALAXY_SERVER, API_KEY, KUBECONFIG
 
 PROFILE_SEARCH_PATH = ['~/.abm/profile.yml', '.abm-profile.yml']
 
@@ -43,6 +41,13 @@ class Context:
 
 
 
+def print_json(obj):
+    print(json.dumps(obj, indent=2))
+
+
+def print_yaml(obj):
+    print(get_yaml_parser().dump(obj, sys.stdout))
+
 
 def connect(context:Context):
     """
@@ -71,16 +76,10 @@ def get_context(profile_name: str):
     return Context(profile_name)
 
 
-def create_parser():
-    print('Creating a YAML parser')
-    return YAML()
-
-
-def get_yaml_parser(parser = create_parser()):
-    if parser is None:
-        print('No parser provided.')
-        parser = create_parser()
-    return parser
+def get_yaml_parser():
+    if lib.parser is None:
+        lib.parser = YAML()
+    return lib.parser
 
 
 def load_profiles():
@@ -102,7 +101,7 @@ def load_profiles():
 
 
 def save_profiles(profiles: dict):
-    yaml = YAML()
+    yaml = get_yaml_parser()
     for profile_path in PROFILE_SEARCH_PATH:
         path = os.path.expanduser(profile_path)
         if os.path.exists(path):

--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -1,7 +1,10 @@
-from common import load_profiles, Context
+from common import load_profiles, save_profiles, get_yaml_parser, Context
+from ruamel.yaml import YAML
+from pprint import pprint
 
 import kubectl
 import users
+import sys
 
 def list(context: Context, args: list):
     profiles = load_profiles()
@@ -10,17 +13,44 @@ def list(context: Context, args: list):
         print(f"{profile}\t{profiles[profile]['url']}")
 
 
-def update(context: Context, args: list):
-    create = False
-    if '-c' in args:
-        create = True
-        args.remove('-c')
-    if '--create' in args:
-        create = True
-        args.remove('--create')
-    if len(args) == 0:
-        print("ERROR: no user specified")
+def create(context: Context, args: list):
+    if len(args) != 2:
+        print("USAGE: abm config create <cloud> /path/to/kube.config")
         return
+    profile_name = args[0]
+    profiles = load_profiles()
+    if profile_name in profiles:
+        print("ERROR: a cloud configuration with that name already exists.")
+        return
+    profiles[profile_name] = { 'url': "", 'key': '', 'kube': args[1]}
+    print(get_yaml_parser().dump(profiles, sys.stdout))
 
-    context.GALAXY_SERVER = kubectl.get_url(context, [])
-    context.API_KEY = users.get_api_key(context, args)
+
+def key(context: Context, args: list):
+    if len(args) != 2:
+        print(f"USAGE: abm config key <cloud> <key>")
+        return
+    profile_name = args[0]
+    key = args[1]
+    profiles = load_profiles()
+    if not profile_name in profiles:
+        print(f"ERROR: Unknown cloud {profile_name}")
+        return
+    profile = profiles[profile_name]
+    profile['key'] = key
+    save_profiles(profiles)
+
+
+def url(context: Context, args: list):
+    if len(args) != 2:
+        print(f"USAGE: abm config key <cloud> <url>")
+        return
+    profile_name = args[0]
+    url = args[1]
+    profiles = load_profiles()
+    if not profile_name in profiles:
+        print(f"ERROR: Unknown cloud {profile_name}")
+        return
+    profile = profiles[profile_name]
+    profile['url'] = url
+    save_profiles(profiles)

--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -1,10 +1,10 @@
 from common import load_profiles, save_profiles, get_yaml_parser, Context
-from ruamel.yaml import YAML
-from pprint import pprint
 
-import kubectl
-import users
 import sys
+import json
+import lib
+
+from common import print_json, print_yaml
 
 def list(context: Context, args: list):
     profiles = load_profiles()
@@ -22,8 +22,10 @@ def create(context: Context, args: list):
     if profile_name in profiles:
         print("ERROR: a cloud configuration with that name already exists.")
         return
-    profiles[profile_name] = { 'url': "", 'key': '', 'kube': args[1]}
-    print(get_yaml_parser().dump(profiles, sys.stdout))
+    profile = { 'url': "", 'key': '', 'kube': args[1]}
+    profiles[profile_name] = profile
+    save_profiles(profiles)
+    print_json(profile)
 
 
 def key(context: Context, args: list):
@@ -39,6 +41,7 @@ def key(context: Context, args: list):
     profile = profiles[profile_name]
     profile['key'] = key
     save_profiles(profiles)
+    print_json(profile)
 
 
 def url(context: Context, args: list):
@@ -54,3 +57,15 @@ def url(context: Context, args: list):
     profile = profiles[profile_name]
     profile['url'] = url
     save_profiles(profiles)
+    print_json(profile)
+
+
+def show(context: Context, args: list):
+    if len(args) != 1:
+        print("USAGE: abm config show <cloud>")
+        return
+    profiles = load_profiles()
+    if args[0] not in profiles:
+        print(f"ERROR: No such cloud {args[0]}")
+        return
+    print_json(profiles[args[0]])

--- a/abm/lib/dataset.py
+++ b/abm/lib/dataset.py
@@ -1,6 +1,6 @@
 from common import connect, Context
 from pprint import pprint
-import yaml
+# import yaml
 
 
 def list(context: Context, args: list):
@@ -59,11 +59,13 @@ def upload(context: Context, args: list):
             history = args[index]
             index += 1
         elif arg == '-c':
+            gi = connect(context)
             history = gi.histories.create_history(args[index]).get('id')
             index += 1
         else:
             print('ERROR: invalid option')
-    gi = connect(context)
+    if gi is None:
+        gi = connect(context)
     pprint(gi.tools.put_url(args[0], history))
 
 

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -215,6 +215,17 @@
     - name: [list, ls]
       help: list configured servers
       handler: config.list
+    - name: [key]
+      help: Set the Galaxy API key for the provided cloud instance
+      handler: config.key
+      params: CLOUD API_KEY
+    - name: [create]
+      help: Create a new cloud configuration.
+      handler: config.create
+    - name: [url]
+      help: Set the URL for the Galaxy server.
+      params: CLOUD URL
+      handler: config.url
 - name: [library, lib]
   help: manage data libraries on the server
   menu:

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -215,13 +215,18 @@
     - name: [list, ls]
       help: list configured servers
       handler: config.list
+    - name: [show, sh]
+      help: disply URL, API key, and kube config for a specific cloud.
+      handler: config.show
+      params: CLOUD
+    - name: [create]
+      help: Create a new cloud configuration.
+      handler: config.create
+      params: "CLOUD KUBECONFIG"
     - name: [key]
       help: Set the Galaxy API key for the provided cloud instance
       handler: config.key
       params: CLOUD API_KEY
-    - name: [create]
-      help: Create a new cloud configuration.
-      handler: config.create
     - name: [url]
       help: Set the URL for the Galaxy server.
       params: CLOUD URL


### PR DESCRIPTION
Add several commands to the `config` subcommand intended to simply the bootstrapping process.

- `abm config create <cloud> /path/to/kube/config`<br/>adds a new entry to the profile.yml file for the named cloud and sets the path to the kube config file.
- `abm config key <cloud> API_KEY`<br/>sets the API key for the named cloud
- `abm config url <cloud> URL`<br/>sets the URL to the Galaxy instance on the cloud
- `abm config show <url>`<br/>prints the entry for the cloud from the profile.yml file.