### PR TITLE
Don't retry forever

### DIFF
--- a/abm/lib/benchmark.py
+++ b/abm/lib/benchmark.py
@@ -312,6 +312,7 @@ def wait_for_jobs(context, gi: GalaxyInstance, invocations: dict):
                     retries -= 1
                 except Exception as e:
                     print(f"ERROR: {e}")
+                    retries -= 1
 
 
 def parse_workflow(workflow_path: str):


### PR DESCRIPTION
The benchmark module would retry forever if an exception other that a `ConnectionError` was raised.