### PR TITLE
Check to ensure histories are not empty before dereferencing them

### DIFF
--- a/abm/lib/history.py
+++ b/abm/lib/history.py
@@ -25,6 +25,10 @@ def pad(value: bool):
 
 
 def print_histories(histories: list):
+    if len(histories) == 0:
+        print("There are no available histories.")
+        return
+    
     id_width = len(histories[0]['id'])
     name_width = longest_name(histories)
 


### PR DESCRIPTION
The `print_histories` method was trying to access `histories[0]` without ensuring that the list contained any elements.