### PR TITLE
88 standalone commands

### DIFF
--- a/.github/workflows/prodrelease.yml
+++ b/.github/workflows/prodrelease.yml
@@ -39,3 +39,16 @@ jobs:
         with:
           file: abm/VERSION
           parser: cat
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install pypa/build
+        run: python -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/abm/__main__.py
+++ b/abm/__main__.py
@@ -79,7 +79,7 @@ def print_main_help(menu_data):
     print(f"        Available SUBCOMMANDS and OPTIONS depend on the command. Use the {bold('help')} subcommand")
     print(f"        to learn more about each of the commands. For example:\n")
     print(f"        $> abm workflow help\n")
-    print("        Copyright 2022 The Galaxy Project\n")
+    print("    Copyright 2022 The Galaxy Project\n")
 
 
 def print_help(menu_data, command):
@@ -95,6 +95,8 @@ def print_help(menu_data, command):
 
     print()
     head("    SYNOPSIS")
+    print(f"        abm [cloud] {command} SUBCOMMAND <ARGS>\n")
+    head("    DESCRIPTION")
     print(f"        {submenu['help']}\n")
     head("    SUBCOMMANDS")
     for menu_item in submenu['menu']:
@@ -103,7 +105,7 @@ def print_help(menu_data, command):
     print(f"        {bold('help')}")
     print("            print this help screen and exit")
     print()
-    print("        Copyright 2022 The Galaxy Project\n")
+    print("    Copyright 2022 The Galaxy Project\n")
 
 
 all_commands = {}

--- a/abm/__main__.py
+++ b/abm/__main__.py
@@ -60,10 +60,10 @@ def command_list(commands:list):
 
 def print_main_help(menu_data):
     print()
-    head("    SYNOPSIS")
+    head("    DESCRIPTION")
     print("        Workflow and data management for remote Galaxy instances")
     print()
-    head("    USAGE")
+    head("    SYNOPSIS")
     print(f"        abm COMMAND [SUBCOMMAND] [OPTIONS]")
     print()
     head("    COMMANDS")

--- a/abm/__main__.py
+++ b/abm/__main__.py
@@ -48,7 +48,7 @@ version_args = ['-v', '--version', 'version']
 
 # TODO Parse this from the menu.yml file.
 # Commands that do not depend on a cloud instance
-stand_alone_commands = ['config', 'experiment', 'exp', 'ex']
+stand_alone_commands = []
 
 def head(text):
     print(bold(text))
@@ -95,7 +95,10 @@ def print_help(menu_data, command):
 
     print()
     head("    SYNOPSIS")
-    print(f"        abm [cloud] {command} SUBCOMMAND <ARGS>\n")
+    if submenu['name'][0] in stand_alone_commands:
+        print(f"        abm {command} SUBCOMMAND <ARGS>\n")
+    else:
+        print(f"        abm [cloud] {command} SUBCOMMAND <ARGS>\n")
     head("    DESCRIPTION")
     print(f"        {submenu['help']}\n")
     head("    SUBCOMMANDS")
@@ -143,6 +146,9 @@ def parse_menu():
         # Use the first name in the list as the main name for the item. The
         # others will be aliased below.
         name = main_menu_item['name'][0]
+        if main_menu_item.get('standalone', False):
+            for item_name in main_menu_item['name']:
+                stand_alone_commands.append(item_name)
         log.debug('Menu name: %s', name)
         for submenu_item in main_menu_item['menu']:
             handler = globals()

--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -93,16 +93,43 @@ def workflows(context: Context, args: list):
         for key,url in workflows.items():
             print(f"{key:10} {url}")
     elif args[0] in ['delete', 'del','rm']:
-        print(f"Deleting elements is not supported at this time. Please edit {userfile} directly.")
+        print(f"Deleting workflows is not supported at this time. Please edit {userfile} directly.")
     elif args[0] in ['add', 'new']:
-        print(f"Adding elements is not supported at this time. Please edit {userfile} directly.")
+        print(f"Adding workflows is not supported at this time. Please edit {userfile} directly.")
     else:
         print(f"ERROR: Unrecognized command {args[0]}")
+
+
+def datasets(context: Context, args: list):
+    userfile = os.path.join(Path.home(), ".abm", "datasets.yml")
+    if len(args) == 0 or args[0] in ['list', 'ls']:
+        datasets = _load_dataset_config(userfile)
+        if datasets is None:
+            return
+        print(f"Datasets defined in {userfile}")
+        for key,url in datasets.items():
+            print(f"{key:10} {url}")
+    elif args[0] in ['delete', 'del','rm']:
+        print(f"Deleting datasets is not supported at this time. Please edit {userfile} directly.")
+    elif args[0] in ['add', 'new']:
+        print(f"Adding datasets is not supported at this time. Please edit {userfile} directly.")
+    else:
+        print(f"ERROR: Unrecognized command {args[0]}")
+
+
+def _load_dataset_config(configfile):
+    if not os.path.exists(configfile):
+        print("ERROR: this instance has not been configured to import datasets.")
+        print(f"Please configure {configfile} to enable dataset imports.")
+        return None
+    with open(configfile, 'r') as f:
+        datasets = yaml.safe_load(f)
+    return datasets
 
 def _load_workflow_config(userfile):
     if not os.path.exists(userfile):
         print("ERROR: this instance has not been configured to import workflows.")
-        print(f"Please configure {userfile} to enable workflow imports")
+        print(f"Please configure {userfile} to enable workflow imports.")
         return None
     with open(userfile, 'r') as f:
         workflows = yaml.safe_load(f)

--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -1,9 +1,8 @@
 from common import load_profiles, save_profiles, get_yaml_parser, Context
 
-import sys
-import json
-import lib
-
+import os
+import yaml
+from pathlib import Path
 from common import print_json, print_yaml
 
 def list(context: Context, args: list):
@@ -83,3 +82,28 @@ def show(context: Context, args: list):
         print(f"ERROR: No such cloud {args[0]}")
         return
     print_json(profiles[args[0]])
+
+def workflows(context: Context, args: list):
+    userfile = os.path.join(Path.home(), ".abm", "workflows.yml")
+    if len(args) == 0 or args[0] in ['list', 'ls']:
+        workflows = _load_workflow_config(userfile)
+        if workflows is None:
+            return
+        print(f"Workflows defined in {userfile}")
+        for key,url in workflows.items():
+            print(f"{key:10} {url}")
+    elif args[0] in ['delete', 'del','rm']:
+        print(f"Deleting elements is not supported at this time. Please edit {userfile} directly.")
+    elif args[0] in ['add', 'new']:
+        print(f"Adding elements is not supported at this time. Please edit {userfile} directly.")
+    else:
+        print(f"ERROR: Unrecognized command {args[0]}")
+
+def _load_workflow_config(userfile):
+    if not os.path.exists(userfile):
+        print("ERROR: this instance has not been configured to import workflows.")
+        print(f"Please configure {userfile} to enable workflow imports")
+        return None
+    with open(userfile, 'r') as f:
+        workflows = yaml.safe_load(f)
+    return workflows

--- a/abm/lib/dataset.py
+++ b/abm/lib/dataset.py
@@ -48,8 +48,9 @@ def delete(context: Context, args: list):
 
 
 def upload(context: Context, args: list):
-    if len(args) == 0:
-        print('ERROR: no dataset file given')
+    if len(args) != 3:
+        print('ERROR: Invalid arguments.  Include the URL, and the ID of an existing history,')
+        print('or the name of a history to be created.')
         return
     index = 1
     gi = None
@@ -65,6 +66,7 @@ def upload(context: Context, args: list):
             index += 1
         else:
             print(f'ERROR: invalid option {arg}')
+
     if gi is None:
         gi = connect(context)
     pprint(gi.tools.put_url(args[0], history))

--- a/abm/lib/dataset.py
+++ b/abm/lib/dataset.py
@@ -86,7 +86,7 @@ def import_from_config(context: Context, args: list):
         history = args[2]
     elif args[1] in ['-c', '--create']:
         gi = connect(context)
-        history = gi.histories.create_history(args[index]).get('id')
+        history = gi.histories.create_history(args[2]).get('id')
     else:
         print(f"Invalid option {args[1]}")
         return
@@ -136,6 +136,15 @@ def find(context: Context, args: list):
 
     ds = datasets[0]
     pprint(ds)
+
+
+def rename(context: Context, args: list):
+    if len(args) != 3:
+        print("ERROR: please provide the history ID, dataset ID, and new name.")
+        return
+    gi = connect(context)
+    result = gi.histories.update_dataset(args[0], args[1], name=args[2])
+    pprint(result)
 
 
 def test(context: Context, args: list):

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -65,7 +65,7 @@
   menu:
     - name: ['upload', 'up']
       handler: dataset.upload
-      params: PATH
+      params: PATH [-id HISTORY_ID | -c "History name"]
       help: upload a data set to the server
     - name: ['download', 'dl']
       handler: dataset.download

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -185,6 +185,7 @@
       params: NAME EMAIL PASSWORD
 - name: [experiment, exp, ex]
   help: execute benchmarking runs on various clouds
+  standalone: true
   menu:
     - name: [run]
       help: run all benchmarks in an experiment
@@ -227,6 +228,7 @@
       handler: kubectl.url
 - name: [config, conf, cfg]
   help: manage configuration profiles
+  standalone: true
   menu:
     - name: [list, ls]
       help: list configured servers

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -236,20 +236,24 @@
       handler: config.create
       params: "CLOUD KUBECONFIG"
     - name: [remove, rm, del]
-      help: emove a cloud configuration entry from the profile.yml
+      help: remove a cloud configuration entry from the profile.yml
       handler: config.remove
       params: CLOUD
     - name: [key]
-      help: Set the Galaxy API key for the provided cloud instance
+      help: set the Galaxy API key for the provided cloud instance
       handler: config.key
       params: CLOUD API_KEY
     - name: [url]
-      help: Set the URL for the Galaxy server.
+      help: set the URL for the Galaxy server.
       params: CLOUD URL
       handler: config.url
     - name: [workflows, workflow, wf]
-      help: manage configuration for import workflows to Galaxy.
+      help: manage configuration to import workflows.
       handler: config.workflows
+      params: "[list|add|delete] ARGS"
+    - name: [datasets, dataset, ds]
+      handler: config.datasets
+      help: manage configuration to import datasets.
       params: "[list|add|delete] ARGS"
 - name: [library, lib]
   help: manage data libraries on the server

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -86,6 +86,10 @@
       handler: dataset.clean
       params: "[STATE [STATE...]]"
       help: deletes and purges all datasets that are not 'ok'
+    - name: [rename, ren]
+      handler: dataset.rename
+      help: rename a dataset
+      params: HISTORY_ID DATASET_ID NAME
 - name:
     - history
     - hist

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -66,11 +66,15 @@
     - name: ['upload', 'up']
       handler: dataset.upload
       params: PATH [-id HISTORY_ID | -c "History name"]
-      help: upload a data set to the server
+      help: upload a dataset to the server from the specified URL
     - name: ['download', 'dl']
       handler: dataset.download
       params: ID PATH
       help: download a dataset from the server
+    - name: ['import', 'imp']
+      handler: dataset.import_from_config
+      params: PATH [-id HISTORY_ID | -c "History name"]
+      help: imports a dataset to the server from a URL specified in the datasets.yml config file.
     - name: ['list', 'ls']
       handler: dataset.list
       help: lists all the datasets on the server

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -243,6 +243,10 @@
       help: Set the URL for the Galaxy server.
       params: CLOUD URL
       handler: config.url
+    - name: [workflows, workflow, wf]
+      help: manage configuration for import workflows to Galaxy.
+      handler: config.workflows
+      params: "[list|add|delete] ARGS"
 - name: [library, lib]
   help: manage data libraries on the server
   menu:

--- a/abm/lib/workflow.py
+++ b/abm/lib/workflow.py
@@ -86,7 +86,6 @@ def import_from_config(context: Context, args:list):
         return
     with open(userfile, 'r') as f:
         workflows = yaml.safe_load(f)
-    pprint(workflows)
     if not key in workflows:
         print(f"ERROR: no such workflow: {key}")
         return


### PR DESCRIPTION
Allow standalone commands, that is commnds that do not rely or a specific Galaxy instance, to be specified in the `menu.yml` file rather than being hard coded.

Closes #88 