### PR TITLE
Allow filtering of jobs by history

### DIFF
--- a/abm/lib/job.py
+++ b/abm/lib/job.py
@@ -8,6 +8,7 @@ log = logging.getLogger('abm')
 
 def list(context: Context, args: list):
     state = ''
+    history_id = None
     log.debug('Processing args')
     log_state = False
     while len(args) > 0:
@@ -18,14 +19,16 @@ def list(context: Context, args: list):
                 return
             state = args.pop(0)
             log_state = True
-
+        elif arg in ['-h', '--history']:
+            history_id = args.pop(0)
+            log.debug(f"Getting jobs from history {history_id}")
     log.debug('Connecting to the Galaxy server')
     gi = connect(context)
     if log_state:
         log.debug(f"Getting jobs with state {state}")
     else:
         log.debug("Getting job list")
-    job_list = gi.jobs.get_jobs(state=state)
+    job_list = gi.jobs.get_jobs(state=state, history_id=history_id)
     log.debug(f"Iterating over job list with {len(job_list)} items")
     for job in job_list:
         print(f"{job['id']}\t{job['state']}\t{job['update_time']}\t{job['tool_id']}")

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -1,4 +1,4 @@
-- name: 
+- name:
     - benchmark
     - bench
   help: 'manage benchmarks'
@@ -158,9 +158,9 @@
   help: manage jobs on the server
   menu:
     - name: [ list, ls ]
-      help: list all jobs, or jobs in a particular state
+      help: list all jobs, or jobs in a particular state. Can filter by a history.
       handler: job.list
-      params: "[-s|--state ok|running|error|waiting]"
+      params: "[-s|--state ok|running|error|waiting] [-h|--history_id historyID]"
     - name: [ show ]
       help: show detailed information about a job
       handler: job.show


### PR DESCRIPTION
Allows limiting the list of jobs to a specific history:

```
> abm gke jobs list -h e2d81e783545f721
9b94239a3e24de23	new	2023-04-25T13:06:21.454443	toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.2
9dda245cafc71040	new	2023-04-25T13:06:21.041935	param_value_from_file
f06cafb6609facdf	ok	2023-04-25T13:05:50.168500	toolshed.g2.bx.psu.edu/repos/lldelisle/revertr2orientationinbam/revertR2orientationInBam/0.0.2
75f4c26313dd3022	ok	2023-04-25T13:01:21.127860	toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1
```