### PR TITLE
Add listing job metrics for all jobs in a history

### DIFF
--- a/abm/lib/job.py
+++ b/abm/lib/job.py
@@ -51,7 +51,30 @@ def metrics(context: Context, args: list):
         print("ERROR: no job ID provided")
         return
     gi = connect(context)
-    metrics = gi.jobs.get_metrics(args[0])
+    if len(args) > 1:
+        arg = args.pop(0)
+        if arg in ['-h', '--history']:
+            history_id = args.pop(0)
+            log.debug(f"Getting metrics for jobs from history {history_id}")
+            job_list = gi.jobs.get_jobs(history_id=history_id)
+            metrics = []
+            for job in job_list:
+                metrics.append({
+                    'job_id': job['id'],
+                    'job_state': job['state'],
+                    'tool_id': job['tool_id'],
+                    'job_metrics': gi.jobs.get_metrics(job['id'])
+                })
+        else:
+            print(f"ERROR: Unrecognized argument {arg}")
+    else:
+        job = gi.jobs.show_job(args[0])
+        metrics = [{
+            'job_id': job['id'],
+            'job_state': job['state'],
+            'tool_id': job['tool_id'],
+            'job_metrics': gi.jobs.get_metrics(args[0])
+        }]
     print(json.dumps(metrics, indent=4))
     # metrics = {}
     # for m in gi.jobs.get_metrics(args[0]):

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -1,4 +1,4 @@
-- name: 
+- name:
     - benchmark
     - bench
   help: 'manage benchmarks'
@@ -174,9 +174,9 @@
       handler: job.cancel
       params: ID
     - name: [ metrics, stats ]
-      help: display runtime metrics for the job
+      help: display runtime metrics for the job, or a list of jobs contained in a history
       handler: job.metrics
-      params: ID
+      params: "[ID | -h|--history historyID]"
 - name: [users, user]
   help: manage users on the Galaxy instance
   menu:


### PR DESCRIPTION
The `metrics` subcommand now returns a list of dicts with some job metadata along the metrics:

```
❯ abm gke jobs metrics -h 34a389071c95afda
[
    {
        "job_id": "68e8e638dde1f7ce",
        "job_state": "ok",
        "tool_id": "__IMPORT_HISTORY__",
        "job_metrics": [
            {
                "title": "Operating System",
                "value": "Linux gkm-galaxy-job-0-59975b7955-fw4sk 5.10.162+ #1 SMP Sat Mar 11 15:59:33 UTC 2023 x86_64 GNU/Linux\n",
                "plugin": "uname",
                "name": "uname",
                "raw_value": "Linux gkm-galaxy-job-0-59975b7955-fw4sk 5.10.162+ #1 SMP Sat Mar 11 15:59:33 UTC 2023 x86_64 GNU/Linux\n"
            },
            {
                "title": "Total System Swap",
                "value": "0 bytes",
                ...
```