### PR TITLE
Run numbering

### DIFF
--- a/abm/lib/experiment.py
+++ b/abm/lib/experiment.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import os
@@ -26,18 +27,20 @@ def run(context: Context, args: list):
 
     :return: True if the benchmarks completed sucessfully. False otherwise.
     """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('benchmark_path')
+    parser.add_argument('-r', '--run-number', default=-1)
+    argv = parser.parse_args(args)
 
-    if len(args) == 0:
-        print("ERROR: No benchmarking configuration provided.")
-        return False
+    benchmark_path = argv.benchmark_path
 
-    benchmark_path = args[0]
     if not os.path.exists(benchmark_path):
         print(f"ERROR: Benchmarking configuration not found {benchmark_path}")
         return False
 
     with open(benchmark_path, 'r') as f:
         config = yaml.safe_load(f)
+    config['start_at'] = argv.run_number
 
     profiles = load_profiles()
     # latch = CountdownLatch(len(config['cloud']))
@@ -66,6 +69,8 @@ def run_on_cloud(cloud: str, config: dict):
     context = Context(cloud)
     namespace = 'galaxy'
     chart = 'anvil/galaxykubeman'
+    start = config['start_at']
+    end = start + config['runs']
     if 'galaxy' in config:
         namespace = config['galaxy']['namespace']
         chart = config['galaxy']['chart']
@@ -76,14 +81,14 @@ def run_on_cloud(cloud: str, config: dict):
             if not helm.update(context, [f"rules/{conf}.yml", namespace, chart]):
                 log.warning(f"job configuration not found: rules/{conf}.yml")
                 continue
-            for n in range(config['runs']):
+            for n in range(start, end):
                 history_name_prefix = f"{n+1} {cloud} {conf}"
                 for workflow_conf in config['benchmark_confs']:
                     benchmark.run(
                         context, workflow_conf, history_name_prefix, config['name']
                     )
     else:
-        for n in range(config['runs']):
+        for n in range(start, end):
             history_name_prefix = f"{n+1} {cloud}"
             for workflow_conf in config['benchmark_confs']:
                 benchmark.run(

--- a/abm/lib/experiment.py
+++ b/abm/lib/experiment.py
@@ -70,6 +70,8 @@ def run_on_cloud(cloud: str, config: dict):
     namespace = 'galaxy'
     chart = 'anvil/galaxykubeman'
     start = config['start_at']
+    if start < 0:
+        start = 1
     end = start + config['runs']
     if 'galaxy' in config:
         namespace = config['galaxy']['namespace']

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -208,7 +208,7 @@
     - name: [wait]
       help: Wait for a job to finish running
       handler: job.wait
-      params: ID
+      params: "ID [-T|--timeout SECONDS]"
     - name: [ metrics, stats ]
       help: display runtime metrics for the job, or a list of jobs contained in a history
       handler: job.metrics
@@ -244,9 +244,9 @@
   standalone: true
   menu:
     - name: [run]
-      help: run all benchmarks in an experiment
+      help: run all benchmarks in an experiment. Use --run-number to specify staring counter.
       handler: experiment.run
-      params: PATH
+      params: "PATH [-r|--run-number N]"
     - name: [summarize, summary]
       help: summarize metrics to a CSV or TSV file.
       handler: experiment.summarize


### PR DESCRIPTION
Use the --run-number option to specify the starting integer when numbering benchmark runs. Closes #169