### PR TITLE
Configuration command

### DIFF
--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -297,7 +297,7 @@
     - name: [url]
       help: derive the URL to access this Galaxy instance
       handler: kubectl.url
-- name: [config, conf, cfg]
+- name: [config, configuration, conf, cfg]
   help: manage configuration profiles
   standalone: true
   menu:


### PR DESCRIPTION
Accept configuration as an alias for the config command.  Closes #279