### PR TITLE
Default master api key

### DIFF
--- a/abm/lib/common.py
+++ b/abm/lib/common.py
@@ -225,11 +225,12 @@ def parse_profile(profile_name: str):
         return nones
     profile = profiles[profile_name]
     kube = None
-    master = 'galaxypassword'
     if 'kube' in profile:
         kube = os.path.expanduser(profile['kube'])
     if 'master' in profile:
         master = profile['master']
+    elif 'key' in profile:
+        master = profile['key']
     return (profile['url'], profile['key'], kube, master)
 
 

--- a/abm/lib/users.py
+++ b/abm/lib/users.py
@@ -76,7 +76,7 @@ def usage(context: Context, args: list):
         return
 
     # TODO the master API key needs to be parameterized or specified in a config file.
-    context.API_KEY = "galaxypassword"
+    context.API_KEY = context.MASTER_KEY
     gi = connect(context)
     id = _get_user_id(gi, args[0])
     if id is None:


### PR DESCRIPTION
Use the user API key as the master API key if the master key has not been specified.

Closes #318 