### PR TITLE
Adds a tools subcommand

### DIFF
--- a/SESSION_NOTES_325.md
+++ b/SESSION_NOTES_325.md
@@ -1,0 +1,46 @@
+# Session Notes: Issue #325 — Add tools subcommand
+
+## 2026-03-16: Initial implementation
+
+### Branch
+`325-tools-subcommand` based on `dev`
+
+### What was done
+
+Created `abm/lib/tools.py` with six subcommands:
+
+1. **`tools list`** — Lists all tools on the server. Supports `--name`, `--section`, and `--id` regex filters. Output: tab-separated ID, version, panel section, name.
+
+2. **`tools show`** — Shows full JSON details for a tool (with `io_details=True` for input/output info).
+
+3. **`tools inputs`** — Lists the inputs required by a tool in a human-readable format (name, type, required flag, label).
+
+4. **`tools search`** — Searches tools by matching a query (regex) against name, ID, and description.
+
+5. **`tools scaffold`** — Generates a YAML input template from a tool's input definition. Handles conditionals (shows default case active, other cases commented), sections, repeats, data/data_collection references, and all scalar types. Comments include labels, help text, allowed values.
+
+6. **`tools run`** — Runs a tool with inputs from a YAML file (`-f`), inline `key=value` args, or both (CLI overrides file). Dataset references use `hda:ID` / `hdca:ID` shorthand. Supports `--wait` to poll until the job completes. Uses BioBlend legacy pipe-delimited key format.
+
+### Key implementation details
+
+- `_scaffold_inputs()` recursively walks the tool input tree, emitting YAML with comments for each input type (conditional, section, repeat, data, boolean, select, integer, float, text, color, hidden)
+- `_parse_value()` converts string values to appropriate types (dataset refs, booleans, numbers)
+- `_resolve_values()` recursively processes a loaded YAML dict to resolve dataset reference strings
+- `_flatten_inputs()` converts nested dicts to pipe-delimited keys for BioBlend's legacy input format
+
+### Files created
+- `abm/lib/tools.py` — new module
+
+### Files modified
+- `abm/lib/menu.yml` — added `tools` menu entry with all 6 subcommands
+- `abm/__main__.py` — added `tools` import
+
+### Testing (on `nlp` instance at `34.11.7.111`)
+- `tools list` — found 2579 tools, filters work correctly
+- `tools list --name fastp` — found 14 fastp versions
+- `tools scaffold "Show beginning1"` — generated correct YAML template
+- `tools run` with inline args — job completed successfully
+- `tools run` with YAML file — job completed successfully
+- `tools run` with YAML file + CLI override — job completed successfully
+- `tools run --wait` — correctly polled and reported job completion
+- All 4 test runs produced output datasets in state `ok`

--- a/abm/__main__.py
+++ b/abm/__main__.py
@@ -19,8 +19,8 @@ import yaml
 # These imports are required because we need Python to be load them to the
 # symbol table so the parse_menu method can find them in globals()
 from lib import (benchmark, config, dataset, experiment, folder,
-                 helm, history, invocation, job, kubectl, library, users,
-                 workflow)
+                 helm, history, invocation, job, kubectl, library, tools,
+                 users, workflow)
 from lib.common import Context
 
 from abm import getVersion

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -346,7 +346,7 @@
     - name: [list, ls]
       handler: tools.do_list
       help: list all tools installed on the server
-      params: "[-n|--name REGEX] [-s|--section REGEX] [-id|--id REGEX]"
+      params: "[-n|--name REGEX] [-s|--section REGEX] [-id|--id REGEX] [-l|--latest]"
     - name: [show]
       handler: tools.show
       help: show detailed information about a tool

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -340,6 +340,33 @@
       handler: config.histories
       help: manage configuration to import histories
       params: "[list|add|delete] ARGS"
+- name: [tools, tool]
+  help: manage and inspect tools on the server
+  menu:
+    - name: [list, ls]
+      handler: tools.do_list
+      help: list all tools installed on the server
+      params: "[-n|--name REGEX] [-s|--section REGEX] [-id|--id REGEX]"
+    - name: [show]
+      handler: tools.show
+      help: show detailed information about a tool
+      params: TOOL_ID
+    - name: [inputs, inp]
+      handler: tools.inputs
+      help: list the inputs required by a tool
+      params: TOOL_ID
+    - name: [search, find]
+      handler: tools.search
+      help: search for tools by name
+      params: QUERY
+    - name: [scaffold, template]
+      handler: tools.scaffold
+      help: generate a YAML input template for a tool
+      params: TOOL_ID
+    - name: [run]
+      handler: tools.run
+      help: run a tool with inputs from a YAML file and/or key=value arguments
+      params: "TOOL_ID --history HISTORY [-f|--file INPUTS.yml] [-w|--wait] [key=value ...]"
 - name: [library, lib]
   help: manage data libraries on the server
   menu:


### PR DESCRIPTION
## Summary

Adds a new `tools` subcommand (#325) so users can list, inspect, and run tools installed on a Galaxy instance.

The command supports six subcommands: 
- `list` with regex filtering by name, section, or tool ID
- `show` for full tool details 
- `inputs` for a human-readable summary of required inputs
- `search` for matching tools by name, ID, or description
- `scaffold` to generate a YAML input template pre-filled with defaults and comments
- `run` to execute a tool with inputs from a YAML file, inline `key=value` arguments, or both.

The `scaffold` + `run` workflow addresses the complexity of Galaxy tool inputs by letting users generate a template, edit it, and pass it back. Dataset references use a concise `hda:ID` / `hdca:ID` shorthand. The `run` command also supports `--wait` to poll until the job completes.

Closes #325