### PR TITLE
Don't return deleted dataset collections

### DIFF
--- a/abm/lib/benchmark.py
+++ b/abm/lib/benchmark.py
@@ -559,6 +559,14 @@ def find_workflow_id(gi, name_or_id):
     return None
 
 
+def _get_active_history_ids(gi):
+    """
+    Returns a set of history IDs for histories that are not deleted or purged.
+    """
+    histories = gi.histories.get_histories(deleted=False)
+    return {h['id'] for h in histories}
+
+
 def find_dataset_id(gi, name_or_id):
     """
     Resolves the human-readable name if a dataset into the unique ID on the
@@ -575,11 +583,14 @@ def find_dataset_id(gi, name_or_id):
         pass
 
     try:
+        active_histories = _get_active_history_ids(gi)
         datasets = gi.datasets.get_datasets(
             name=name_or_id
         )  # , deleted=True, purged=True)
         for ds in datasets:
             if ds['state'] == 'ok' and not ds['deleted'] and ds['visible']:
+                if ds.get('history_id') not in active_histories:
+                    continue
                 return ds['id']
             else:
                 print(f"Dataset {ds['id']} is not valid.")
@@ -600,19 +611,21 @@ def find_collection_id(gi, name):
     :return: The unique Galaxy ID of the collection or None if the collection
     can not be located.
     """
+    active_histories = _get_active_history_ids(gi)
     kwargs = {'limit': 10000, 'offset': 0}
     datasets = gi.datasets.get_datasets(**kwargs)
     if len(datasets) == 0:
         print('No datasets found')
         return None
     for dataset in datasets:
-        # print(f"Checking if dataset {dataset['name']} == {name}")
         if dataset['type'] == 'collection' and dataset['name'].strip() == name:
             if (
                 dataset['populated_state'] == 'ok'
                 and not dataset['deleted']
                 and dataset['visible']
             ):
+                if dataset.get('history_id') not in active_histories:
+                    continue
                 return dataset['id']
     return None
 


### PR DESCRIPTION
Fixes a bug where `find_collection_id()` and `find_dataset_id()` in `benchmark.py` could return datasets or collections belonging to deleted/purged histories. When a history is purged, Galaxy purges the individual datasets but does not mark collection-level records as deleted, so the existing `not dataset['deleted']` check was insufficient.

Both functions now pre-fetch the set of active (non-deleted) history IDs via `_get_active_history_ids()` and skip any candidate whose `history_id` is not in that set. This uses a single API call to get the history list rather than per-candidate lookups.

Closes #328
