### PR TITLE
Add optional parameters to config create command

### DIFF
--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from pathlib import Path
 
@@ -21,17 +22,27 @@ def do_list(context: Context, args: list):
         print(f"{profile}\t{profiles[profile]['url']}")
 
 
-def create(context: Context, args: list):
-    if len(args) != 2:
-        print("USAGE: abm config create <cloud> /path/to/kube.config")
-        return
-    profile_name = args[0]
+def create(context: Context, argv: list):
+    parser = argparse.ArgumentParser(prog='abm config create')
+    parser.add_argument('profile_name', help='name of the profile to create')
+    parser.add_argument('--url', help='Galaxy server URL')
+    parser.add_argument('--key', help='Galaxy API key')
+    parser.add_argument('--kube', help='path to kubeconfig file')
+
+    args = parser.parse_args(argv)
+
     profiles = load_profiles()
-    if profile_name in profiles:
+    if args.profile_name in profiles:
         print("ERROR: a cloud configuration with that name already exists.")
         return
-    profile = {"url": "", "key": "", "kube": args[1]}
-    profiles[profile_name] = profile
+
+    profile = {
+        "url": args.url or "",
+        "key": args.key or "",
+        "kube": args.kube or ""
+    }
+
+    profiles[args.profile_name] = profile
     save_profiles(profiles)
     print_json(profile)
 

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -319,7 +319,7 @@
     - name: [create, new]
       help: create a new cloud configuration.
       handler: config.create
-      params: "CLOUD KUBECONFIG"
+      params: "PROFILE [--url URL] [--key KEY] [--kube KUBECONFIG]"
     - name: [remove, rm, del]
       help: remove a cloud configuration entry from the profile.yml
       handler: config.remove

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,125 @@
+import json
+import tempfile
+import os
+from pathlib import Path
+from unittest.mock import patch, mock_open
+import pytest
+
+from abm.lib.config import create
+from abm.lib.common import Context
+
+
+@pytest.fixture
+def temp_profiles():
+    """Create a temporary profiles.yml file for testing."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+        f.write("test_profile:\n  url: 'http://example.com'\n  key: 'test_key'\n  kube: '/tmp/test.config'\n")
+        temp_file = f.name
+
+    with patch('abm.lib.common.find_config') as mock_find:
+        mock_find.return_value = temp_file
+        yield temp_file
+
+    # Clean up
+    os.unlink(temp_file)
+
+
+def test_config_create_minimal(temp_profiles, capsys):
+    """Test creating a config with just profile name."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, ['test_new'])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == ''
+    assert output['key'] == ''
+    assert output['kube'] == ''
+
+
+def test_config_create_with_url(temp_profiles, capsys):
+    """Test creating a config with URL specified."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, ['test_new', '--url', 'https://galaxy.example.com'])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == 'https://galaxy.example.com'
+    assert output['key'] == ''
+    assert output['kube'] == ''
+
+
+def test_config_create_with_key(temp_profiles, capsys):
+    """Test creating a config with API key specified."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, ['test_new', '--key', 'my_api_key'])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == ''
+    assert output['key'] == 'my_api_key'
+    assert output['kube'] == ''
+
+
+def test_config_create_with_kube(temp_profiles, capsys):
+    """Test creating a config with kubeconfig path specified."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, ['test_new', '--kube', '/path/to/kube.config'])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == ''
+    assert output['key'] == ''
+    assert output['kube'] == '/path/to/kube.config'
+
+
+def test_config_create_with_all_params(temp_profiles, capsys):
+    """Test creating a config with all parameters specified."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, [
+        'test_new',
+        '--url', 'https://galaxy.example.com',
+        '--key', 'my_api_key',
+        '--kube', '/path/to/kube.config'
+    ])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == 'https://galaxy.example.com'
+    assert output['key'] == 'my_api_key'
+    assert output['kube'] == '/path/to/kube.config'
+
+
+def test_config_create_duplicate_profile(temp_profiles, capsys):
+    """Test creating a config with existing profile name should fail."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    create(context, ['test_profile'])  # This profile already exists in fixture
+
+    captured = capsys.readouterr()
+    assert "ERROR: a cloud configuration with that name already exists." in captured.out
+
+
+def test_config_create_missing_profile_name(temp_profiles):
+    """Test creating a config without profile name should fail with SystemExit."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    with pytest.raises(SystemExit):
+        create(context, [])
+
+
+def test_config_create_help(temp_profiles):
+    """Test that help argument works."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    with pytest.raises(SystemExit):
+        create(context, ['--help'])


### PR DESCRIPTION
Enhances the `config create` command to support optional parameters for URL, API key, and kubeconfig path. Previously the command required both a profile name and kubeconfig path as positional arguments. Now only the profile name is required, and all other values can be set via optional flags or left empty.

The enhancement adds three new optional parameters: `--url` to set the Galaxy server URL, `--key` to set the API key, and `--kube` to set the kubeconfig path. This allows for more flexible profile creation where users can specify only the values they know at creation time and set others later using the existing `config url` and `config key` commands.

The implementation uses argparse for proper command-line parsing and maintains the same profile structure, ensuring compatibility with existing profiles and other config commands.

Closes #333