### PR TITLE
Add config kube command to set kubeconfig path

### DIFF
--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -97,6 +97,22 @@ def url(context: Context, args: list):
     print_json(profile)
 
 
+def kube(context: Context, args: list):
+    if len(args) != 2:
+        print(f"USAGE: abm config kube <cloud> <kube_path>")
+        return
+    profile_name = args[0]
+    kube_path = args[1]
+    profiles = load_profiles()
+    if not profile_name in profiles:
+        print(f"ERROR: Unknown cloud {profile_name}")
+        return
+    profile = profiles[profile_name]
+    profile["kube"] = kube_path
+    save_profiles(profiles)
+    print_json(profile)
+
+
 def show(context: Context, args: list):
     if len(args) != 1:
         print("USAGE: abm config show <cloud>")

--- a/abm/lib/menu.yml
+++ b/abm/lib/menu.yml
@@ -332,6 +332,10 @@
       help: set the URL for the Galaxy server.
       params: CLOUD URL
       handler: config.url
+    - name: [kube]
+      help: set the path to the kubeconfig file for the provided cloud instance
+      handler: config.kube
+      params: CLOUD KUBE_PATH
     - name: [workflows, workflow, wf]
       help: manage configuration to import workflows.
       handler: config.workflows

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch, mock_open
 import pytest
 
-from abm.lib.config import create
+from abm.lib.config import create, kube
 from abm.lib.common import Context
 
 
@@ -123,3 +123,44 @@ def test_config_create_help(temp_profiles):
 
     with pytest.raises(SystemExit):
         create(context, ['--help'])
+
+
+def test_config_kube_success(temp_profiles, capsys):
+    """Test setting kube path for existing profile."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    kube(context, ['test_profile', '/new/path/to/config'])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out.strip())
+
+    assert output['url'] == 'http://example.com'
+    assert output['key'] == 'test_key'
+    assert output['kube'] == '/new/path/to/config'
+
+
+def test_config_kube_unknown_profile(temp_profiles, capsys):
+    """Test setting kube path for unknown profile."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    kube(context, ['unknown_profile', '/path/to/config'])
+
+    captured = capsys.readouterr()
+    assert "ERROR: Unknown cloud unknown_profile" in captured.out
+
+
+def test_config_kube_invalid_args(temp_profiles, capsys):
+    """Test kube command with invalid argument count."""
+    context = Context('server', 'key', 'kubeconfig')
+
+    # Test with only one argument
+    kube(context, ['test_profile'])
+
+    captured = capsys.readouterr()
+    assert "USAGE: abm config kube <cloud> <kube_path>" in captured.out
+
+    # Test with no arguments
+    kube(context, [])
+
+    captured = capsys.readouterr()
+    assert "USAGE: abm config kube <cloud> <kube_path>" in captured.out


### PR DESCRIPTION
Adds a new `config kube` command to set the kubeconfig file path for existing profiles, matching the pattern of the existing `config key` and `config url` commands. This provides a consistent interface for managing all three profile settings (URL, API key, and kubeconfig path).

Closes #334