### PR TITLE
Bootstrap configuration for datasets

### DIFF
--- a/abm/lib/config.py
+++ b/abm/lib/config.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from urllib.parse import urlparse
 
 import yaml
 from common import (
@@ -263,6 +264,122 @@ def _load_config(filepath):
         return yaml.safe_load(f)
 
 
+def _extract_filename_from_url(url):
+    """Extract filename from URL for use as dataset name."""
+    parsed = urlparse(url)
+    filename = os.path.basename(parsed.path)
+    return filename if filename else "dataset"
+
+
+def _import_dataset_with_metadata(gi, history_id, dataset_config):
+    """Import a dataset with optional name and datatype metadata."""
+    if isinstance(dataset_config, str):
+        # Simple URL format
+        url = dataset_config
+        file_name = _extract_filename_from_url(url)
+        dataset._import_from_url(gi, history_id, url, file_name=file_name)
+    elif isinstance(dataset_config, dict):
+        # Dictionary format with optional name and datatype
+        url = dataset_config.get('url')
+        if not url:
+            print(f"ERROR: dataset config missing required 'url' field: {dataset_config}")
+            return
+
+        # Extract optional parameters
+        file_name = dataset_config.get('name')
+        if not file_name:
+            file_name = _extract_filename_from_url(url)
+
+        file_type = dataset_config.get('datatype')
+
+        # Build kwargs for import
+        kwargs = {'file_name': file_name}
+        if file_type:
+            kwargs['file_type'] = file_type
+
+        dataset._import_from_url(gi, history_id, url, **kwargs)
+    else:
+        print(f"ERROR: dataset config must be URL string or dict: {dataset_config}")
+
+
+def _process_datasets_v1(gi, datasets):
+    """Process datasets in version 1 format with enhanced metadata support."""
+    # Check if datasets is a simple list or dictionary
+    if isinstance(datasets, list):
+        # Simple list format - create default history
+        print(f"Importing {len(datasets)} datasets into default history...")
+        new_history = gi.histories.create_history(name="Configured Datasets")
+        dataset_history = new_history['id']
+
+        for dataset_config in datasets:
+            try:
+                _import_dataset_with_metadata(gi, dataset_history, dataset_config)
+            except Exception as e:
+                print(f"ERROR: failed to import dataset {dataset_config}: {e}")
+
+    elif isinstance(datasets, dict):
+        # Dictionary format - group by history name
+        for history_name, dataset_list in datasets.items():
+            print(
+                f"Importing {len(dataset_list)} datasets into history '{history_name}'..."
+            )
+
+            # Get or create the named history
+            histories = gi.histories.get_histories(name=history_name)
+            if histories:
+                dataset_history = histories[0]['id']
+            else:
+                new_history = gi.histories.create_history(name=history_name)
+                dataset_history = new_history['id']
+
+            for dataset_config in dataset_list:
+                try:
+                    _import_dataset_with_metadata(gi, dataset_history, dataset_config)
+                except Exception as e:
+                    print(f"ERROR: failed to import dataset {dataset_config}: {e}")
+    else:
+        print("ERROR: datasets section must be either a list or dictionary")
+
+
+def _process_datasets_v0(gi, datasets):
+    """Process datasets in legacy version 0 format (backward compatibility)."""
+    # Check if datasets is a simple list or dictionary
+    if isinstance(datasets, list):
+        # Simple list format - create default history
+        print(f"Importing {len(datasets)} datasets into default history...")
+        new_history = gi.histories.create_history(name="Configured Datasets")
+        dataset_history = new_history['id']
+
+        for url in datasets:
+            try:
+                dataset._import_from_url(gi, dataset_history, url)
+            except Exception as e:
+                print(f"ERROR: failed to import dataset from {url}: {e}")
+
+    elif isinstance(datasets, dict):
+        # Dictionary format - group by history name
+        for history_name, urls in datasets.items():
+            print(
+                f"Importing {len(urls)} datasets into history '{history_name}'..."
+            )
+
+            # Get or create the named history
+            histories = gi.histories.get_histories(name=history_name)
+            if histories:
+                dataset_history = histories[0]['id']
+            else:
+                new_history = gi.histories.create_history(name=history_name)
+                dataset_history = new_history['id']
+
+            for url in urls:
+                try:
+                    dataset._import_from_url(gi, dataset_history, url)
+                except Exception as e:
+                    print(f"ERROR: failed to import dataset from {url}: {e}")
+    else:
+        print("ERROR: datasets section must be either a list or dictionary")
+
+
 def bootstrap(context: Context, args: list):
     """Configure a Galaxy instance by uploading datasets, histories, and workflows from a YAML configuration file."""
     if len(args) < 2:
@@ -291,6 +408,10 @@ def bootstrap(context: Context, args: list):
         print("ERROR: configuration file is empty")
         return
 
+    # Determine configuration version (default to 0 for backward compatibility)
+    config_version = config.get('version', 0)
+    print(f"Processing bootstrap configuration version {config_version}")
+
     # Process histories
     if 'histories' in config:
         histories = config['histories']
@@ -302,46 +423,19 @@ def bootstrap(context: Context, args: list):
             except Exception as e:
                 print(f"ERROR: failed to import history from {url}: {e}")
 
-    # Process datasets - support both simple list and grouped by history
+    # Process datasets using version-appropriate handler
     if 'datasets' in config:
         datasets = config['datasets']
         gi = connect(context)
 
-        # Check if datasets is a simple list or dictionary
-        if isinstance(datasets, list):
-            # Simple list format - create default history
-            print(f"Importing {len(datasets)} datasets into default history...")
-            new_history = gi.histories.create_history(name="Configured Datasets")
-            dataset_history = new_history['id']
-
-            for url in datasets:
-                try:
-                    dataset._import_from_url(gi, dataset_history, url)
-                except Exception as e:
-                    print(f"ERROR: failed to import dataset from {url}: {e}")
-
-        elif isinstance(datasets, dict):
-            # Dictionary format - group by history name
-            for history_name, urls in datasets.items():
-                print(
-                    f"Importing {len(urls)} datasets into history '{history_name}'..."
-                )
-
-                # Get or create the named history
-                histories = gi.histories.get_histories(name=history_name)
-                if histories:
-                    dataset_history = histories[0]['id']
-                else:
-                    new_history = gi.histories.create_history(name=history_name)
-                    dataset_history = new_history['id']
-
-                for url in urls:
-                    try:
-                        dataset._import_from_url(gi, dataset_history, url)
-                    except Exception as e:
-                        print(f"ERROR: failed to import dataset from {url}: {e}")
+        if config_version == 0:
+            # Legacy format for backward compatibility
+            _process_datasets_v0(gi, datasets)
+        elif config_version == 1:
+            # Enhanced format with name and datatype support
+            _process_datasets_v1(gi, datasets)
         else:
-            print("ERROR: datasets section must be either a list or dictionary")
+            print(f"ERROR: unsupported configuration version: {config_version}")
 
     # Process workflows (with tool installation)
     if 'workflows' in config:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,11 +1,12 @@
 import json
 import tempfile
 import os
+import yaml
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 import pytest
 
-from abm.lib.config import create, kube
+from abm.lib.config import create, kube, bootstrap, _extract_filename_from_url, _import_dataset_with_metadata
 from abm.lib.common import Context
 
 
@@ -192,3 +193,200 @@ def test_config_kube_invalid_args(temp_profiles, capsys):
 
     captured = capsys.readouterr()
     assert "USAGE: abm config kube <cloud> <kube_path>" in captured.out
+
+
+# Tests for new bootstrap functionality
+
+def test_extract_filename_from_url():
+    """Test filename extraction from URLs."""
+    assert _extract_filename_from_url("https://example.com/data/file.fastq.gz") == "file.fastq.gz"
+    assert _extract_filename_from_url("http://example.com/path/to/dataset.bam") == "dataset.bam"
+    assert _extract_filename_from_url("https://example.com/data/") == "dataset"
+    assert _extract_filename_from_url("https://example.com") == "dataset"
+
+
+@patch('abm.lib.config.dataset')
+def test_import_dataset_with_metadata_url_only(mock_dataset):
+    """Test importing dataset with URL only (simple format)."""
+    mock_gi = MagicMock()
+    history_id = "test_history_id"
+    dataset_config = "https://example.com/data/file.fastq"
+
+    _import_dataset_with_metadata(mock_gi, history_id, dataset_config)
+
+    mock_dataset._import_from_url.assert_called_once_with(
+        mock_gi, history_id, "https://example.com/data/file.fastq", file_name="file.fastq"
+    )
+
+
+@patch('abm.lib.config.dataset')
+def test_import_dataset_with_metadata_with_name(mock_dataset):
+    """Test importing dataset with custom name."""
+    mock_gi = MagicMock()
+    history_id = "test_history_id"
+    dataset_config = {
+        "url": "https://example.com/data/file.fastq",
+        "name": "custom_name"
+    }
+
+    _import_dataset_with_metadata(mock_gi, history_id, dataset_config)
+
+    mock_dataset._import_from_url.assert_called_once_with(
+        mock_gi, history_id, "https://example.com/data/file.fastq", file_name="custom_name"
+    )
+
+
+@patch('abm.lib.config.dataset')
+def test_import_dataset_with_metadata_with_datatype(mock_dataset):
+    """Test importing dataset with custom datatype."""
+    mock_gi = MagicMock()
+    history_id = "test_history_id"
+    dataset_config = {
+        "url": "https://example.com/data/file.fastq",
+        "name": "custom_name",
+        "datatype": "fastqsanger"
+    }
+
+    _import_dataset_with_metadata(mock_gi, history_id, dataset_config)
+
+    mock_dataset._import_from_url.assert_called_once_with(
+        mock_gi, history_id, "https://example.com/data/file.fastq",
+        file_name="custom_name", file_type="fastqsanger"
+    )
+
+
+@patch('abm.lib.config.dataset')
+def test_import_dataset_with_metadata_missing_url(mock_dataset, capsys):
+    """Test importing dataset with missing URL."""
+    mock_gi = MagicMock()
+    history_id = "test_history_id"
+    dataset_config = {"name": "custom_name"}
+
+    _import_dataset_with_metadata(mock_gi, history_id, dataset_config)
+
+    captured = capsys.readouterr()
+    assert "ERROR: dataset config missing required 'url' field" in captured.out
+    mock_dataset._import_from_url.assert_not_called()
+
+
+@patch('abm.lib.config.dataset')
+def test_import_dataset_with_metadata_invalid_config(mock_dataset, capsys):
+    """Test importing dataset with invalid config format."""
+    mock_gi = MagicMock()
+    history_id = "test_history_id"
+    dataset_config = 123  # Invalid type
+
+    _import_dataset_with_metadata(mock_gi, history_id, dataset_config)
+
+    captured = capsys.readouterr()
+    assert "ERROR: dataset config must be URL string or dict" in captured.out
+    mock_dataset._import_from_url.assert_not_called()
+
+
+@pytest.fixture
+def temp_bootstrap_config():
+    """Create temporary bootstrap configuration files for testing."""
+    configs = {}
+
+    # Version 0 config (legacy)
+    v0_config = {
+        "datasets": {
+            "Test History": [
+                "https://example.com/file1.fastq",
+                "https://example.com/file2.fastq"
+            ]
+        },
+        "histories": ["https://example.com/history1"],
+        "workflows": ["https://example.com/workflow1"]
+    }
+
+    # Version 1 config (new format)
+    v1_config = {
+        "version": 1,
+        "datasets": {
+            "Test History": [
+                "https://example.com/file1.fastq",
+                {
+                    "url": "https://example.com/file2.fastq",
+                    "name": "custom_file2"
+                },
+                {
+                    "url": "https://example.com/file3.fastq",
+                    "name": "custom_file3",
+                    "datatype": "fastqsanger"
+                }
+            ]
+        }
+    }
+
+    for version, config in [("v0", v0_config), ("v1", v1_config)]:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            yaml.dump(config, f)
+            configs[version] = f.name
+
+    yield configs
+
+    # Clean up
+    for config_file in configs.values():
+        os.unlink(config_file)
+
+
+@patch('abm.lib.config.workflow')
+@patch('abm.lib.config.history')
+@patch('abm.lib.config.connect')
+@patch('abm.lib.config.Context')
+def test_bootstrap_version_0_backward_compatibility(mock_context_class, mock_connect, mock_history, mock_workflow, temp_bootstrap_config, capsys):
+    """Test bootstrap with version 0 config (backward compatibility)."""
+    mock_context = MagicMock()
+    mock_context_class.return_value = mock_context
+
+    mock_gi = MagicMock()
+    mock_connect.return_value = mock_gi
+    mock_gi.histories.create_history.return_value = {'id': 'new_history_id'}
+    mock_gi.histories.get_histories.return_value = []
+
+    context = Context('server', 'key', 'kubeconfig')
+    config_file = temp_bootstrap_config['v0']
+
+    with patch('abm.lib.config.dataset') as mock_dataset:
+        bootstrap(context, ['test_server', config_file])
+
+    captured = capsys.readouterr()
+    assert "Processing bootstrap configuration version 0" in captured.out
+
+    # Verify legacy import was called
+    assert mock_dataset._import_from_url.call_count == 2
+
+
+@patch('abm.lib.config.workflow')
+@patch('abm.lib.config.history')
+@patch('abm.lib.config.connect')
+@patch('abm.lib.config.Context')
+def test_bootstrap_version_1_enhanced_format(mock_context_class, mock_connect, mock_history, mock_workflow, temp_bootstrap_config, capsys):
+    """Test bootstrap with version 1 config (enhanced format)."""
+    mock_context = MagicMock()
+    mock_context_class.return_value = mock_context
+
+    mock_gi = MagicMock()
+    mock_connect.return_value = mock_gi
+    mock_gi.histories.create_history.return_value = {'id': 'new_history_id'}
+    mock_gi.histories.get_histories.return_value = []
+
+    context = Context('server', 'key', 'kubeconfig')
+    config_file = temp_bootstrap_config['v1']
+
+    with patch('abm.lib.config.dataset') as mock_dataset:
+        bootstrap(context, ['test_server', config_file])
+
+    captured = capsys.readouterr()
+    assert "Processing bootstrap configuration version 1" in captured.out
+
+    # Verify enhanced import was called with different parameter sets
+    calls = mock_dataset._import_from_url.call_args_list
+    assert len(calls) == 3
+
+    # Check that different parameter combinations were used
+    assert calls[0][1]['file_name'] == "file1.fastq"  # URL only
+    assert calls[1][1]['file_name'] == "custom_file2"  # Custom name
+    assert calls[2][1]['file_name'] == "custom_file3"  # Custom name + datatype
+    assert calls[2][1]['file_type'] == "fastqsanger"


### PR DESCRIPTION
Enhances the `config bootstrap` command to support more flexible dataset configuration options including custom names, datatypes, and configuration file versioning.

The updated bootstrap configuration now supports specifying dataset names and datatypes in addition to URLs. Datasets can be configured as simple URLs (where the filename becomes the dataset name) or as dictionaries with explicit URL, name, and datatype fields. The implementation also introduces bootstrap configuration versioning to ensure backward compatibility while enabling future enhancements.

The enhancement leverages BioBlend's existing capabilities for specifying file metadata during upload, providing users with granular control over how datasets are imported into Galaxy histories during bulk configuration operations.

Closes #339